### PR TITLE
feat: Add MEMORY_METADATA to MCP configuration examples

### DIFF
--- a/claude-code-mcp.json
+++ b/claude-code-mcp.json
@@ -11,7 +11,8 @@
         "OPENAI_API_KEY": "",
         "OPENAI_MODEL": "text-embedding-3-small",
         "MCP_SERVER_NAME": "memory-server",
-        "MCP_SERVER_PORT": "3000"
+        "MCP_SERVER_PORT": "3000",
+        "MEMORY_METADATA": "user:yourname,server:hostname"
       }
     }
   }

--- a/mcp.json
+++ b/mcp.json
@@ -11,7 +11,8 @@
         "OPENAI_API_KEY": "",
         "OPENAI_MODEL": "text-embedding-3-small",
         "MCP_SERVER_NAME": "memory-server",
-        "MCP_SERVER_PORT": "3000"
+        "MCP_SERVER_PORT": "3000",
+        "MEMORY_METADATA": "user:yourname,server:hostname"
       }
     }
   }


### PR DESCRIPTION
Added MEMORY_METADATA environment variable to both MCP configuration files to demonstrate metadata tracking functionality. Users can customize the placeholder values to track their own user identification and server information.

🤖 Generated with [Claude Code](https://claude.ai/code)